### PR TITLE
Implement spritemaps

### DIFF
--- a/MatteEngine/Graphics.cpp
+++ b/MatteEngine/Graphics.cpp
@@ -154,11 +154,11 @@ SDL_Texture* convert_surface_to_texture(SDL_Surface* sfc, Graphics* gfx = Graphi
 
 void apply_partial_texture_to_screen(
 	SDL_Texture* full_texture,
-	const SDL_Rect* bounding_rectangle,
+	const SDL_Rect bounding_rectangle,
 	PositionComponent* pos,
 	Graphics* gfx = Graphics::getInstance()
 ) {
-	SDL_Rect destination = { pos->x, pos->y, bounding_rectangle->w, bounding_rectangle->h};
+	SDL_Rect destination = { pos->x, pos->y, bounding_rectangle.w, bounding_rectangle.h};
 
-	SDL_RenderCopy(gfx->getRenderer(), full_texture, bounding_rectangle, &destination);
+	SDL_RenderCopy(gfx->getRenderer(), full_texture, &bounding_rectangle, &destination);
 }

--- a/MatteEngine/Graphics.h
+++ b/MatteEngine/Graphics.h
@@ -43,5 +43,5 @@ public:
 SDL_Texture* build_string_texture(const char* message, TTF_Font* font, int& width, int& height);
 void apply_surface_to_screen(SDL_Texture* sfc, SDL_Rect, Graphics* our_window);
 void apply_surface_to_screen(SDL_Texture* sfc,  PositionComponent*, Graphics* our_window);
-void apply_partial_texture_to_screen(SDL_Texture*, const SDL_Rect*, PositionComponent*, Graphics*);
+void apply_partial_texture_to_screen(SDL_Texture*, const SDL_Rect, PositionComponent*, Graphics*);
 SDL_Texture* convert_surface_to_texture(SDL_Surface* sfc, Graphics* gfx);

--- a/MatteEngine/Main.cpp
+++ b/MatteEngine/Main.cpp
@@ -92,8 +92,11 @@ int main(int argc, char *argv[])
 	SystemManager::load_systems();
 
 	EntityManager* mgr = new EntityManager();
-	Entity* die_sprite = ESprite::makeSprite("die.png", 1);
-	mgr->register_entity(die_sprite);
+	Entity* test_sprite = ESprite::makeSprite("data/sprites/dwarf_1.png", 1);
+	mgr->register_entity(test_sprite);
+
+	// make sprite_map_component for our basic entity
+	ESprite::register_sprite_map_dev(test_sprite);
 
 	// make our test map and tileset
 	Tileset* test_tiles = new Tileset("blue");
@@ -103,7 +106,7 @@ int main(int argc, char *argv[])
 	Map* test_map = new Map("test_map.mmp");
 	test_map->register_map_tiles(mgr);
 
-	SMusic::load_music("test_music.mp3");
+	//SMusic::load_music("test_music.mp3");
 	update(mgr, our_window);
 
 	our_window->shutdown();

--- a/MatteEngine/MatteEngine.vcxproj
+++ b/MatteEngine/MatteEngine.vcxproj
@@ -126,6 +126,7 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="AnimationComponent.cpp" />
     <ClCompile Include="Color.cpp" />
     <ClCompile Include="Config.cpp" />
     <ClCompile Include="Entity.cpp" />

--- a/MatteEngine/MatteEngine.vcxproj.filters
+++ b/MatteEngine/MatteEngine.vcxproj.filters
@@ -63,6 +63,9 @@
     <ClCompile Include="SpriteMapComponent.cpp">
       <Filter>Source Files\Components</Filter>
     </ClCompile>
+    <ClCompile Include="AnimationComponent.cpp">
+      <Filter>Source Files\Components</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="Logging.h">

--- a/MatteEngine/Render.h
+++ b/MatteEngine/Render.h
@@ -6,6 +6,7 @@
 #include "AnimationComponent.h"
 #include "DrawableComponent.h"
 #include "PositionComponent.h"
+#include "SpriteMapComponent.h"
 #include "Entity.h"
 #include "Graphics.h"
 #include "spdlog\spdlog.h"
@@ -37,12 +38,35 @@ namespace SRender {
 		apply_surface_to_screen(drawable->get_texture(), position, gfx);
 	}
 
+	void draw_entity_from_anim_description(const Entity* entity, Graphics* gfx = Graphics::getInstance()) {
+		DrawableComponent *drawable = dynamic_cast<DrawableComponent*>(entity->get_component(DRAWABLE));
+		PositionComponent *position = dynamic_cast<PositionComponent*>(entity->get_component(POSITION));
+		SpriteMapComponent *sprite_map = dynamic_cast<SpriteMapComponent*>(entity->get_component(SPRITE_MAP));
+		if (position == nullptr || drawable == nullptr || sprite_map == nullptr) {
+			render_logger->error("Drawing entity with ID {} broke", entity->get_entity_id());
+		}
+
+		apply_partial_texture_to_screen(
+			drawable->get_texture(), 
+			sprite_map->get_clipping_rect_for_animation("south_walk_neutral"), 
+			position, 
+			gfx
+		);
+	}
+
 	void update(EntityManager* entity_mgr, Graphics* gfx = Graphics::getInstance()) {
 		std::vector<Entity*> drawable_entities = entity_mgr->entities_matching_component(DRAWABLE);
+		std::vector<Entity*> animate_entities = entity_mgr->entities_matching_component(SPRITE_MAP);
 		std::sort(drawable_entities.begin(), drawable_entities.end(), sorter);
 
 		for (auto entity : drawable_entities) {
-			draw_single_entity(entity, gfx);
+			SpriteMapComponent *sprite_map = dynamic_cast<SpriteMapComponent*>(entity->get_component(SPRITE_MAP));
+			if (sprite_map == nullptr) {
+				draw_single_entity(entity, gfx);
+			}
+			else {
+				draw_entity_from_anim_description(entity, gfx);
+			}
 		}
 	}
 } 

--- a/MatteEngine/Render.h
+++ b/MatteEngine/Render.h
@@ -56,7 +56,6 @@ namespace SRender {
 
 	void update(EntityManager* entity_mgr, Graphics* gfx = Graphics::getInstance()) {
 		std::vector<Entity*> drawable_entities = entity_mgr->entities_matching_component(DRAWABLE);
-		std::vector<Entity*> animate_entities = entity_mgr->entities_matching_component(SPRITE_MAP);
 		std::sort(drawable_entities.begin(), drawable_entities.end(), sorter);
 
 		for (auto entity : drawable_entities) {

--- a/MatteEngine/Sprite.h
+++ b/MatteEngine/Sprite.h
@@ -3,7 +3,9 @@
 #include <string>
 #include "DrawableComponent.h"
 #include "PositionComponent.h"
+#include "SpriteMapComponent.h"
 #include "Entity.h"
+#include "ComponentList.h"
 #include "spdlog\spdlog.h"
 
 auto sprite_logger = spdlog::stdout_color_mt("Sprite.h");
@@ -17,5 +19,24 @@ namespace ESprite {
 		base->register_component(position);
 		sprite_logger->info("made a sprite from file: {}", sprite_filename);
 		return base;
+	}
+
+	void register_sprite_map_dev(Entity* target_entity) {
+		std::map<std::string, std::pair< int, int > > sheet_description = {
+			{"south_walk_left", {0, 0}},
+			{"south_walk_neutral", {0, 1}},
+			{"south_walk_right", {0, 2}},
+			{"west_walk_left", {1, 0}},
+			{"west_walk_left", {1, 1}},
+			{"west_walk_left", {1, 2}},
+			{"east_walk_left", {2, 0}},
+			{"east_walk_left", {2, 1}},
+			{"east_walk_left", {2, 2}},
+			{"north_walk_left", {3, 0}},
+			{"north_walk_left", {3, 1}},
+			{"north_walk_left", {3, 2}},
+		};
+		SpriteMapComponent* sprite_map_c = new SpriteMapComponent(32, 32, sheet_description);
+		target_entity->register_component(sprite_map_c);
 	}
 }

--- a/MatteEngine/SpriteMapComponent.cpp
+++ b/MatteEngine/SpriteMapComponent.cpp
@@ -9,14 +9,16 @@ SDL_Rect SpriteMapComponent::get_clipping_rect_for_animation(std::string animati
 	it = this->sheet_mapping.find(animation_descriptor);
 	if (it == this->sheet_mapping.end()) {
 		sprite_map_c_logger->error("Tried to load animation: {}, but failed", animation_descriptor);
-		return dest_rect; // TODO: change this when function gets used
+		return dest_rect; // TODO: change this when function gets used maybe?
 	}
 
 	std::pair<int, int> coords = it->second; 
 	dest_rect.h = this->sprite_height;
 	dest_rect.w = this->sprite_width;
-	dest_rect.x = coords.first * this->sprite_width;
-	dest_rect.y = coords.second * this->sprite_height;
+
+	// x and y are flipped on the rect for reasons unknown
+	dest_rect.x = coords.second * this->sprite_width;
+	dest_rect.y = coords.first * this->sprite_height;
 
 	return dest_rect;
 }

--- a/MatteEngine/SpriteMapComponent.cpp
+++ b/MatteEngine/SpriteMapComponent.cpp
@@ -1,3 +1,4 @@
+#include "ComponentList.h"
 #include "SpriteMapComponent.h"
 
 auto sprite_map_c_logger = spdlog::stdout_color_mt("SpriteMapComponent.h");

--- a/MatteEngine/SpriteMapComponent.h
+++ b/MatteEngine/SpriteMapComponent.h
@@ -11,13 +11,16 @@
 
 class SpriteMapComponent : public Component {
 	static const ComponentTypes c_type = SPRITE_MAP;
-	SDL_Texture* sprite_sheet;
 	std::map<std::string, std::pair<int, int> > sheet_mapping;
 	int sprite_width, sprite_height;
 
 public:
-	SpriteMapComponent(int width, int height, SDL_Texture* _s_sheet, std::map<std::string, std::pair< int, int> > _sheet_mapping) : 
-		sprite_sheet{ _s_sheet }, sprite_width{ width }, sprite_height{ height }, sheet_mapping{ _sheet_mapping }  {}
+	// TODO: add a constructor that takes a DrawableComponent and pulls the SDL_Texture from it
+	SpriteMapComponent(int width, int height, std::map<std::string, std::pair< int, int> > _sheet_mapping) : 
+		sprite_width{ width }, sprite_height{ height }, sheet_mapping{ _sheet_mapping }  {}
 
 	SDL_Rect get_clipping_rect_for_animation(std::string animation_descriptor);
+	ComponentTypes component_type() {
+		return this->c_type;
+	}
 };


### PR DESCRIPTION
This PR adds sprite maps as a component that can be added to an entity and rendered appropriately.

**Missing AnimationComponent that will allow the sprite map segment to be selected by descriptor**